### PR TITLE
Update endpoint

### DIFF
--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -18,7 +18,7 @@
 const defaults = {
   baseUrl: "https://educamosclm.castillalamancha.es",
   endpoints: {
-    messages: "/back/familias/mensajes/",
+    messages: "/back/familias/mensajes",
     messageDetails: "/back/familias/mensajes/#?enviado=false",
     attachment: "/back/familias/mensajes/adjunto/#",
     leido: "/back/familias/mensajes/leido/#",

--- a/src/workers/educamos-worker.ts
+++ b/src/workers/educamos-worker.ts
@@ -114,7 +114,7 @@ export default class EducamosWorker {
     filter: EducamosMessageFilter = { leido: false }
   ): Promise<Array<EducamosMessage>> {
     let currentMessages: Array<EducamosMessage> = [];
-
+    Logger.info("Retrieving messages...")
     page.on("request", async (request) => {
       try {
         if (


### PR DESCRIPTION
This pull request introduces a minor fix to the messages endpoint URL and adds a log statement for better traceability when retrieving messages. These changes help ensure correct API usage and improve debugging during message retrieval.

- **API Endpoint Fix:**
  * Removed the trailing slash from the `messages` endpoint in `defaults`, ensuring consistency with the expected API format.

- **Logging Improvement:**
  * Added an informational log statement before retrieving messages in `EducamosWorker` to aid in debugging and monitoring.